### PR TITLE
github: fix permissions for codeql integration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '42 20 * * 6'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Codeql workflow needs more than just the default content:read permission