### PR TITLE
senders: check tags for None keys/values

### DIFF
--- a/journalpump/senders/base.py
+++ b/journalpump/senders/base.py
@@ -45,9 +45,10 @@ class Tagged:
         output = self._tags.copy()
         if tags:
             for tag_name, tag_value in tags.items():
-                sanitized_name = self.unsafe_tag_name_chars.sub("_", tag_name).strip("_")
-                sanitized_value = self.unsafe_tag_value_chars.sub("_", tag_value).strip("_")
-                output[sanitized_name] = sanitized_value
+                if tag_name is not None and tag_value is not None:
+                    sanitized_name = self.unsafe_tag_name_chars.sub("_", tag_name).strip("_")
+                    sanitized_value = self.unsafe_tag_value_chars.sub("_", tag_value).strip("_")
+                    output[sanitized_name] = sanitized_value
         return output
 
     def replace_tags(self, tags):

--- a/test/unit/senders/test_base.py
+++ b/test/unit/senders/test_base.py
@@ -7,6 +7,7 @@ import pytest
     "input_tags,expected_output_tags",
     [
         ({"foo": "bar"}, {"foo": "bar"}),
+        ({"foo": "bar", "bar": None, None: "baz"}, {"foo": "bar"}),
         ({"foo|wow,": "super!cool"}, {"foo_wow": "super!cool"}),
         ({"host": "localhost:1234"}, {"host": "localhost_1234"}),
         ({"base64": "YmFzZTY0Cg=="}, {"base64": "YmFzZTY0Cg"}),


### PR DESCRIPTION
Only include tags that have no None-valued keys/values.