### PR TITLE
senders: Mitigate issue with GCP logging quota

### DIFF
--- a/journalpump/senders/base.py
+++ b/journalpump/senders/base.py
@@ -14,6 +14,8 @@ else:
     import re  # type: ignore[no-redef]
 
 KAFKA_COMPRESSED_MESSAGE_OVERHEAD = 30
+
+# GCP logging also relies on this MAX message size
 MAX_KAFKA_MESSAGE_SIZE = 1024**2  # 1 MiB
 
 MAX_ERROR_MESSAGES = 8

--- a/journalpump/senders/google_cloud_logging.py
+++ b/journalpump/senders/google_cloud_logging.py
@@ -23,6 +23,15 @@ class GoogleCloudLoggingSender(LogSender):
         0: "EMERGENCY",
     }
 
+    # A bit on the safe side, not exactly 256KB but this
+    # is an approximation anyway
+    # according to https://cloud.google.com/logging/quotas
+    _LOG_ENTRY_QUOTA = 250 * 1024
+
+    # Somewhat arbitrary maximum message size choosen, this gives a 56K
+    # headroom for the other fields in the LogEntry
+    _MAX_MESSAGE_SIZE = 200 * 1024
+
     def __init__(self, *, config, googleapiclient_request_builder=None, **kwargs):
         super().__init__(config=config, max_send_interval=config.get("max_send_interval", 0.3), **kwargs)
         credentials = None
@@ -62,6 +71,18 @@ class GoogleCloudLoggingSender(LogSender):
         for message in messages:
             msg_str = message.decode("utf8")
             msg = json.loads(msg_str)
+
+            # This might not measure exactly 256K but should be a good enough approximation to handle this error.
+            # We try truncating the message if it isn't possible then it is skip.
+            if len(message) > self._LOG_ENTRY_QUOTA:
+                DEFAULT_MESSAGE = "Log entry can't be logged because its size is greater than GCP logging quota of 256K"
+                if "MESSAGE" in msg:
+                    msg["MESSAGE"] = f'{msg["MESSAGE"][:self._MAX_MESSAGE_SIZE]}[MESSAGE TRUNCATED]'
+                    messsage_size = len(json.dumps(msg, ensure_ascii=False).encode("utf-8"))
+                    if messsage_size > self._LOG_ENTRY_QUOTA:
+                        msg = {"MESSAGE": DEFAULT_MESSAGE}
+                else:
+                    msg = {"MESSAGE": DEFAULT_MESSAGE}
             timestamp = msg.pop("timestamp", None)
             journald_priority = msg.pop("PRIORITY", None)
 
@@ -75,7 +96,7 @@ class GoogleCloudLoggingSender(LogSender):
             if timestamp is not None:
                 entry["timestamp"] = timestamp[:26] + "Z"  # assume timestamp to be UTC
             if journald_priority is not None:
-                severity = GoogleCloudLoggingSender._SEVERITY_MAPPING.get(journald_priority, "DEFAULT")
+                severity = self._SEVERITY_MAPPING.get(journald_priority, "DEFAULT")
                 entry["severity"] = severity
             body["entries"].append(entry)
 


### PR DESCRIPTION
https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write
https://cloud.google.com/logging/quotas

# WHAT

This PR is doing two things:

1. Not retrying to send logs that return with HTTP status code 4xx. Instead those logs are simply skipped.
2. Filtering out any `LogEntry` that is bigger than 256K