### PR TITLE
websockets: use client.connect instead of connect

### DIFF
--- a/journalpump/senders/websocket.py
+++ b/journalpump/senders/websocket.py
@@ -16,7 +16,8 @@ import snappy  # pylint: disable=import-error
 import socket
 import ssl
 import time
-import websockets
+import websockets.client
+import websockets.exceptions
 
 
 @enum.unique
@@ -178,7 +179,7 @@ class WebsocketRunner(Thread):
             )
 
         ws_compr = None if self.websocket_compression == WebsocketCompression.none else str(self.websocket_compression)
-        return await websockets.connect(  # pylint:disable=no-member
+        return await websockets.client.connect(  # pylint:disable=no-member
             self.websocket_uri,
             ssl=ssl_context,
             compression=ws_compr,


### PR DESCRIPTION
In websockets v14+ the signature for `connect` has changed. We can use `client.connect` to work across this [breaking change.](https://websockets.readthedocs.io/en/stable/howto/upgrade.html)

In <v14 it will alias to the default `connect` method, and in v14+ it will use the `websockets.legacy` module ensuring compatibility. Once we pin websockets on v14+ then we can switch to using the new `connect` API.